### PR TITLE
edit config and reaction roles edit

### DIFF
--- a/cogs/Ping.py
+++ b/cogs/Ping.py
@@ -11,6 +11,5 @@ class Ping(commands.Cog):
         await ctx.channel.send('pong')
 
 
-
 def setup(bot):
     bot.add_cog(Ping(bot))

--- a/cogs/ReactionRoles.py
+++ b/cogs/ReactionRoles.py
@@ -11,21 +11,33 @@ class ReactionRoles(commands.Cog):
     #when bot runs send embed in read only channel for members to react on embed to assign roles to a member
     @commands.Cog.listener()
     async def on_ready(self):
-        #channelID = 974865668262477865
+        
         channel = self.bot.get_channel(int(channelID))
         
-        embed=discord.Embed(color=0xFFEA00)
+        embed=discord.Embed(color=0xF1C414)
         embed.title='React for Role Assigment'
-        embed.description='Test Role: :fire:'
-        await channel.send(embed=embed)
+        
+        desStr = ''
+        keys = reaction_roles.keys()
+        for i in keys:
+            desStr += '{}: {}\n'.format(i, reaction_roles[i])
+
+        embed.description=desStr
+        msg = await channel.send(embed=embed)
+
+        for i in keys:
+            await msg.add_reaction(i)
 
     #listens for reaction on message in a channel and adds role depending on emoji
     @commands.Cog.listener()
     async def on_reaction_add(self, reaction, member):
-        #channelID = 974865668262477865
-        if reaction.message.channel.id == int(channelID) and reaction.emoji in reaction_roles.keys():
-            Role = discord.utils.get(member.guild.roles, name=reaction_roles[reaction.emoji])
-            await member.add_roles(Role)
+        
+        if member.id != self.bot.user.id:
+            if reaction.message.channel.id == int(channelID) and reaction.emoji in reaction_roles.keys():
+                role = discord.utils.get(member.guild.roles, name=reaction_roles[reaction.emoji])
+                print('{} choose the role {}'.format(member.display_name), reaction_roles[reaction.emoji])
+                await member.add_roles(role)
+
             
 
 

--- a/cogs/Welcome.py
+++ b/cogs/Welcome.py
@@ -9,7 +9,7 @@ class Welcome(commands.Cog):
     @commands.command()
     async def on_message_join(self, memeber):
         channel = self.get_channel()
-        embed=discord.Embed(color=0xFFEA00)
+        embed=discord.Embed(color=0xF1C414)
         embed.title = 'Welcome {memeber.name}'
         embed.description = 'Thank you for joining {memeber.guild.name}'
         embed.set_thumbnail(url = memeber.avatar_url)

--- a/config/config.py
+++ b/config/config.py
@@ -12,8 +12,13 @@ reaction_roles = {
 """
 
 reaction_roles = {
-    '🔥':'Test Role'
+    '⚡':'EE Comp',
+    '☀️':'EE Power',
+    '📻':'EE RF',
+    '🔊':'EE Signals & Comms',
+    '💻':'CpE Comp',
+    '🕹️':'CpE VLSI'
 }
 
 #channel ID of where the emebed will be sent that can be reacted on to add roles
-channelID = 974865668262477865
+channelID = 980143575083929601


### PR DESCRIPTION
slayed some Tech Debt
also
- edited config for the roles with their corresponding emojis
- re-did embed that sends what roles and emojis for the reaction roles embed to change via the config
- bot now sends the emojis that can be used to get a role onto the embed so the user doesn't have to scroll through the list of emojis 
- edit giving the roles so that when the bot adds the emojis, then it doesn't get the role 
- changed the color of all embeds to 0xF1C414 (side note: might want to add embed color to config file)